### PR TITLE
feat: blogs for a particular tag

### DIFF
--- a/bloggitt/core/urls.py
+++ b/bloggitt/core/urls.py
@@ -15,11 +15,13 @@ urlpatterns = [
     path('api/like/<slug:slug>/', PostLikeAPIToggle.as_view(), name='like-api-toggle'),
     path('detail/<slug:slug>/', views.postdetail, name='post_detail'),
     path('detail/<slug:slug>/Favourites', views.Favorites, name='Favorites'),
-    path('fetch', views.fetch, name="fetch")
+    path('fetch', views.fetch, name="fetch"),
     path('profile-update/', ProfileUpdateView.as_view(), name='profile-update'),
     path('profile/', ProfileView.as_view(), name='profile'),
     path('about/',views.about,name='about'),
     path('search/',views.search,name='search'),
+
+    path('tags/<slug:slug>/', views.posts_by_tag, name='posts_by_tag'),
 ]
 
 from django.conf import settings

--- a/bloggitt/core/views.py
+++ b/bloggitt/core/views.py
@@ -19,6 +19,7 @@ from django.db.models import Q
 from django.contrib import messages
 from django.http import HttpResponse, HttpResponseRedirect
 from django.db import IntegrityError
+from taggit.models import Tag
 
 import datetime
 def default(o):
@@ -268,3 +269,10 @@ class ProfileUpdateView(LoginRequiredMixin, TemplateView):
 
     def get(self, request, *args, **kwargs):
         return self.post(request, *args, **kwargs)
+
+
+def posts_by_tag(request, slug):
+    tags = Tag.objects.filter(slug=slug).values_list('name', flat=True)
+    posts = Post.objects.filter(tags__name__in=tags)
+
+    return render(request, 'postsbytag.html', { 'posts': posts })

--- a/bloggitt/templates/detail.html
+++ b/bloggitt/templates/detail.html
@@ -8,7 +8,9 @@
   <h3 class="title">{{ post.title }}</h3>
   <p class="author">{{ post.author }} | {{ post.created_on }}</p>
     {% for tag in post.tags.all %}
-     <h3 style="display: inline;"><span class="badge badge-primary">#{{ tag.name }}</span></h3>
+    <a href="{% url 'posts_by_tag' tag.slug %}">
+      <h3 style="display: inline;"><span class="badge badge-primary">#{{ tag.name }}</span></h3>
+    </a>
     {% endfor %}
     <br><br>
   <p class="author detail">

--- a/bloggitt/templates/postsbytag.html
+++ b/bloggitt/templates/postsbytag.html
@@ -1,0 +1,14 @@
+{% extends "base.html" %} {% block title %} Bloggit {% endblock title %} 
+{% block content %} {% include "header.html" %} {% include "description.html" %}
+
+<div class="blogs">
+    <h1>Posts for clicked tag</h1>
+    {% for post in posts %}
+        <article class="blog">
+            <h3 class="title">{{ post.title }}</h3>
+            <a href="{% url 'post_detail' post.slug %}" class="button">"Read More  →"</a>
+        </article>
+    {% endfor %}
+</div>
+
+{% endblock content %}


### PR DESCRIPTION
**Issue fixed:** #64

**Features added**:
Clicking on any tag on any post will render a template showing all the posts having that tag included.

**Note**:
Each tag is linked with an href tag to render the `postsbytag.html` page whose endpoint is - 
`http://127.0.0.1:8000/tags/<slug:slug>/` where `slug` is the slug of the tag clicked.

**Screenshots**:
![2](https://user-images.githubusercontent.com/46227193/102176998-9d65ae00-3ec8-11eb-931e-2440e3478610.PNG)
